### PR TITLE
Feat/optional tooltips

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,7 +1,10 @@
-from .tooltips import TooltipManager, apply_tooltips
-from .tooltips.categories import register_all_tooltips
+# Set this to True to disable all tooltips
+DISABLE_TOOLTIPS = False
 
-# Register tooltips immediately after import
+if not DISABLE_TOOLTIPS:
+    from .tooltips import TooltipManager, apply_tooltips
+    from .tooltips.categories import register_all_tooltips
+
 from comfy.utils import ProgressBar
 from tqdm import tqdm
 from .node_configs.node_configs import CombinedMeta
@@ -654,4 +657,5 @@ if hasattr(PromptServer, "instance"):
         [web.static("/ryanontheinside_web_async", (Path(__file__).parent.absolute() / "ryanontheinside_web_async").as_posix())]
     )
 #register tooltips after all classes are initialized
-register_all_tooltips()
+if not DISABLE_TOOLTIPS:
+    register_all_tooltips()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui_ryanonyheinside"
 description = "Custom nodes introducing everything-reactivity and timelines to ComfyUI"
-version = "2.0.5"
+version = "2.0.6"
 license = {file = "LICENSE"}
 
 dependencies = ["pygame","opencv-python==4.10.0","scipy","torchaudio", "pillow","librosa==0.10.2","pymunk==6.8.1","matplotlib","openunmix","mido","scikit-image"]

--- a/tooltips/__init__.py
+++ b/tooltips/__init__.py
@@ -3,9 +3,7 @@ Tooltip management system for ComfyUI nodes.
 """
 
 from .tooltip_manager import TooltipManager, apply_tooltips
-from .categories import register_all_tooltips
 
 __all__ = ['TooltipManager', 'apply_tooltips']
 
-# Register tooltips when the module is imported
-register_all_tooltips()
+


### PR DESCRIPTION
# Disable Tooltips Option

Closes #41 

Adds ability to disable tooltips by setting `DISABLE_TOOLTIPS = True` in `__init__.py`.

## Changes
- Added `DISABLE_TOOLTIPS` flag to `__init__.py`
- Removed automatic tooltip registration from `tooltips/__init__.py`
- Made tooltip registration conditional in main `__init__.py`

## Motivation
The tooltip registration system fights with some versions of python

## Testing
- Set `DISABLE_TOOLTIPS = True` to disable all tooltips
- Set `DISABLE_TOOLTIPS = False` to enable tooltips