### PR TITLE
Fix/case insens externals

### DIFF
--- a/external_integration.py
+++ b/external_integration.py
@@ -1,20 +1,28 @@
 import os
 
+def get_case_insensitive_path(base_dir, target_name):
+    """Find a directory path case-insensitively within base_dir."""
+    if not os.path.exists(base_dir):
+        return None
+    for name in os.listdir(base_dir):
+        if name.lower() == target_name.lower():
+            return os.path.join(base_dir, name)
+    return None
+
 # Variables to track the availability of external modules
-alp_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "ComfyUI-AdvancedLivePortrait")
-HAS_ADVANCED_LIVE_PORTRAIT = os.path.exists(alp_path)
+parent_dir = os.path.dirname(os.path.dirname(__file__))
+
+alp_path = get_case_insensitive_path(parent_dir, "ComfyUI-AdvancedLivePortrait")
+HAS_ADVANCED_LIVE_PORTRAIT = alp_path is not None
 print(f"Checking for AdvancedLivePortrait at: {alp_path}")
 
-acn_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "ComfyUI-Advanced-ControlNet")
-HAS_ADVANCED_CONTROLNET = os.path.exists(acn_path)
+acn_path = get_case_insensitive_path(parent_dir, "ComfyUI-Advanced-ControlNet")
+HAS_ADVANCED_CONTROLNET = acn_path is not None
 print(f"Checking for Advanced-ControlNet at: {acn_path}")
 
-#WIP
-ad_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "ComfyUI-AnimateDiff-Evolved")
-HAS_ANIMATEDIFF = os.path.exists(ad_path)
+ad_path = get_case_insensitive_path(parent_dir, "ComfyUI-AnimateDiff-Evolved")
+HAS_ANIMATEDIFF = ad_path is not None
 print(f"Checking for AnimateDiff-Evolved at: {ad_path}")
-
-# HAS_ANIMATEDIFF=False
 
 # Conditional imports for AdvancedLivePortrait
 if HAS_ADVANCED_LIVE_PORTRAIT:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui_ryanonyheinside"
 description = "Custom nodes introducing everything-reactivity and timelines to ComfyUI"
-version = "2.0.6"
+version = "2.0.7"
 license = {file = "LICENSE"}
 
 dependencies = ["pygame","opencv-python==4.10.0","scipy","torchaudio", "pillow","librosa==0.10.2","pymunk==6.8.1","matplotlib","openunmix","mido","scikit-image"]


### PR DESCRIPTION
# Make directory checks case-agnostic

Closes #40 

## Changes
- Added `get_case_insensitive_path` helper function to find directories case-insensitively
- Modified directory existence checks to use case-insensitive matching
- Removed commented-out WIP flags and debug code

## Motivation
The previous implementation used `os.path.exists()` which is case-sensitive on Windows. This could cause issues if users installed node packs with different casing than expected (e.g., `comfyui-advancedliveportrait` vs `ComfyUI-AdvancedLivePortrait`).

## Testing
The changes can be tested by:
1. Installing node packs with different casing (e.g., lowercase or uppercase variants)
2. Verifying the integration still works regardless of directory case
3. Checking console output to confirm correct paths are found