### PR TITLE
Updated Flex Image Transform node with edge_mode

### DIFF
--- a/nodes/images/flex_images.py
+++ b/nodes/images/flex_images.py
@@ -1016,6 +1016,7 @@ class FlexImageTransform(FlexImageBase):
             "transform_type": (["translate", "rotate", "scale"],),
             "x_value": ("FLOAT", {"default": 0.0, "min": -1000.0, "max": 1000.0, "step": 0.1}),
             "y_value": ("FLOAT", {"default": 0.0, "min": -1000.0, "max": 1000.0, "step": 0.1}),
+            "edge_mode": (["extend", "wrap", "reflect", "none"],),
         })
         return base_inputs
 
@@ -1023,8 +1024,8 @@ class FlexImageTransform(FlexImageBase):
     def get_modifiable_params(cls):
         return ["x_value", "y_value", "None"]
 
-    def apply_effect_internal(self, image: np.ndarray, transform_type: str, x_value: float, y_value: float, **kwargs) -> np.ndarray:
-        return transform_image(image, transform_type, x_value, y_value)
+    def apply_effect_internal(self, image: np.ndarray, transform_type: str, x_value: float, y_value: float, edge_mode: str, **kwargs) -> np.ndarray:
+        return transform_image(image, transform_type, x_value, y_value, edge_mode)
 
 @apply_tooltips
 class FlexImageHueShift(FlexImageBase):


### PR DESCRIPTION
Added "edge_mode" to Flex Image Transform node to let users choose between:
- extend (duplicates edge pixels)
- wrap (tiles image)
- reflect (reflected over each axis),
- none (black pixels in empty space)

Image demonstrating testing via attached workflow:

![tested_flex_image_transform](https://github.com/user-attachments/assets/140f345d-3501-4fe8-a4dc-4a3ad7d1d4bb)
[ryan_flex_image_transform_test.json](https://github.com/user-attachments/files/20856612/ryan_flex_image_transform_test.json)
