### PR TITLE
Fix crashing in flex_audio_visualizer.py

### DIFF
--- a/nodes/audio/flex_audio_visualizer.py
+++ b/nodes/audio/flex_audio_visualizer.py
@@ -507,7 +507,7 @@ class FlexAudioVisualizerLine(FlexAudioVisualizerBase):
         start_y = padded_height // 2 - target_y
         
         # Extract the correctly positioned region
-        image = padded_image[start_y:start_y + screen_height, start_x:start_x + screen_width]
+        image = padded_image[start_y:start_y + screen_height, start_x:start_x + screen_width].copy()
 
         return image
 


### PR DESCRIPTION
Fixes #90 

The FlexAudioVisualizerLineNode creates a large padded_image for every frame to handle rotation without clipping. When it slices the final image out, it returns a view of that large array. Since these views are stored in a list for the entire animation duration, the large padded arrays are kept in memory, quickly consuming all available RAM.  Use .copy() to return a new array instead of a view of the huge padded_image and then it can garbage collected for each frame.